### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/dingyuwdy/66a3c2fc-cae6-4a7b-bfd0-26a582f078cf/b4e781b6-99ee-4d73-81e2-df6bb85c849c/_apis/work/boardbadge/1363063c-55ce-46c6-94b9-2a76080c91e7)](https://dev.azure.com/dingyuwdy/66a3c2fc-cae6-4a7b-bfd0-26a582f078cf/_boards/board/t/b4e781b6-99ee-4d73-81e2-df6bb85c849c/Microsoft.RequirementCategory)
 # test


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/dingyuwdy/66a3c2fc-cae6-4a7b-bfd0-26a582f078cf/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.